### PR TITLE
ci: fix DCO check

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -28,5 +28,5 @@ jobs:
           # Comma-separated list of emails that should be ignored during DCO checks
           # DCO_CHECK_EXCLUDE_EMAILS: ${{ inputs.exclude-emails }}
         run: |
-          pip3 install -U dco-check
+          pip3 install -U git+https://github.com/aasseman/dco-check.git@pull_request_target_support
           dco-check


### PR DESCRIPTION
Official version of `dco-check` does not support GH event pull_request_target. Now install `dco-check` from our fork that supports it.

https://github.com/christophebedard/dco-check/pull/121