### PR TITLE
chore: remove ISA dependency from poetry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           cache: poetry
 
       - name: Install dependencies
-        run: poetry install --without isa
+        run: poetry install
 
       - name: Black formatter
         run: poetry run black --check --diff --color .

--- a/poetry.lock
+++ b/poetry.lock
@@ -59,24 +59,6 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
-name = "autoagora-isa"
-version = "0.1.1"
-description = ""
-category = "dev"
-optional = false
-python-versions = ">=3.8,<3.11"
-develop = false
-
-[package.dependencies]
-py-indexer-selection = "^1.0.0"
-
-[package.source]
-type = "git"
-url = "ssh://git@github.com/semiotic-ai/autoagora-isa.git"
-reference = "08142a5dcf3cd44c957921d67792d5188d4894ea"
-resolved_reference = "08142a5dcf3cd44c957921d67792d5188d4894ea"
-
-[[package]]
 name = "babel"
 version = "2.10.3"
 description = "Internationalization utilities"
@@ -650,19 +632,6 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "py-indexer-selection"
-version = "1.0.0"
-description = ""
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.source]
-type = "legacy"
-url = "https://us-west1-python.pkg.dev/the-graph-artifacts/isa/simple"
-reference = "isa-artifacts"
 
 [[package]]
 name = "pyasn1"
@@ -1364,7 +1333,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "9ae1b6534220c0ba44b4034b98f4e5c5871ca677f601785939f54e1286227681"
+content-hash = "14e106b9f7eb73199300a3ee5bf79a64cc3e20ba978b8a99fb52ff934e023ea0"
 
 [metadata.files]
 absl-py = [
@@ -1387,7 +1356,6 @@ attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
-autoagora-isa = []
 babel = [
     {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
     {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
@@ -2038,11 +2006,6 @@ protobuf = [
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-]
-py-indexer-selection = [
-    {file = "py_indexer_selection-1.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0f52b8f314443ec016b27d688352697ca88c988eeb4874fe3f7800a11489755"},
-    {file = "py_indexer_selection-1.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:169385c9f7f6be8de19ac7c6ee08b8ac12a62146194a7ed7e1483a253b2070ee"},
-    {file = "py_indexer_selection-1.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84d031d0ceb686e5bcf6976ff4eae1ce380540e2db1535865fa477a1adff8300"},
 ]
 pyasn1 = [
     {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,6 @@ classifiers = [
 packages = [
     { include = "autoagora_agents" },
 ]
-[tool.poetry.group.isa.dependencies]
-autoagora-isa = {git = "ssh://git@github.com/semiotic-ai/autoagora-isa.git", rev = "08142a5dcf3cd44c957921d67792d5188d4894ea"}
-
-
-
 [tool.poetry.group.dev.dependencies]
 pytest-cov = "^4.0.0"
 
@@ -32,11 +27,6 @@ upload_to_repository = false
 version_source = "tag_only"
 build_command = false
 upload_to_release = false
-
-[[tool.poetry.source]]
-name = "isa-artifacts"
-url = "https://us-west1-python.pkg.dev/the-graph-artifacts/isa/simple/"
-secondary = true
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"


### PR DESCRIPTION
Realized that having the private ISA dependency tracked in poetry, even as an optional group, is a problem for people contributing to this project and AutoAgora.
From now on, experimenters will be expected to manually install the ISA from the private artifact repo with pip in the poetry environment when needed.